### PR TITLE
Clone opaqueData to prevent mutation of original model

### DIFF
--- a/pkg/tests/specs/DecoratorTests.js
+++ b/pkg/tests/specs/DecoratorTests.js
@@ -98,7 +98,7 @@
     return checkState({modelFroze: true, inputsFroze: true}, {modelFroze, inputsFroze});
   };
 
-  export const testPrivateDataCanBeUpdateed = async () => {
+  export const testPrivateDataCanBeUpdated = async () => {
     const particle = await makeParticle(
         `
             , myDecorator({privateData}, inputs, state) { 
@@ -108,5 +108,18 @@
     Decorator.setOpaqueData("fonts", makeTestData());
     Decorator.maybeDecorateModel(particle.impl.render({fonts: 'fonts'}), particle);
     const decoratedModel =  Decorator.maybeDecorateModel(particle.impl.render({fonts: 'fonts'}), particle);
-    return checkState({x: decoratedModel.myfonts.models[0].privateData.x}, {x: 'Hello'});
+    return checkState({x: decoratedModel.myfonts.models[0].privateData.x}, {x: 'HelloHello'});
+  };
+
+  export const testPrivateDataUpdateDoNotMutateOriginalInput = async () => {
+    const particle = await makeParticle(
+        `
+            , myDecorator({privateData}, inputs, state) { 
+                return {privateData: { x: "Hello" + (privateData.x || "") } };
+            }       
+    `);
+    const testData = makeTestData();
+    Decorator.setOpaqueData("fonts", testData);
+    Decorator.maybeDecorateModel(particle.impl.render({fonts: 'fonts'}), particle);
+    return checkState({x: testData[0].privateData}, {x: undefined});
   };

--- a/pkg/ts/core/Decorator.ts
+++ b/pkg/ts/core/Decorator.ts
@@ -16,7 +16,7 @@ const opaqueData = {};
 
 export const Decorator = {
   setOpaqueData(name, data) {
-    opaqueData[name] = data;
+    opaqueData[name] = deepCopy(data);
     return name;
   },
   getOpaqueData(name) {
@@ -78,8 +78,8 @@ const maybeDecorate = (models, decorator, particle) => {
       const immutableModel = Object.freeze(deepCopy(model));
       const decorated = decorator(immutableModel, immutableInputs, immutableState);
       // set new privateData from returned
-      const privateData = decorated.privateData;
-      return { ...decorated, ...immutableModel, privateData };
+      model.privateData = decorated.privateData;
+      return { ...decorated, ...model,  };
     });
     // sort (possible that all values undefined)
     models.sort(sortByLc('sortKey'));


### PR DESCRIPTION
Modification to privateData do not pollute the original data given by the app. Still suboptimal, but a
later PR could use a wrapper approach to decoration.



