### PR TITLE
Really fix Service contract

### DIFF
--- a/pkg/Library/App/Worker/App.js
+++ b/pkg/Library/App/Worker/App.js
@@ -50,18 +50,21 @@ export const App = class {
       case 'restore':
         return this.restore(request);
     }
-    const result =
+    // this code is tricky for performance sake
+    const resultPromise =
+      // may be null
       this.dispatchServiceRequest({request})
+      // must be a promise
       || this.appService({request})
       ;
-    return await result;
+    return await resultPromise;
 }
   async appService({request}) {
     const value = await this.onservice?.('user', 'host', request);
     log('service:', request?.kind || '-', request?.msg, '=', value);
     return value;
   }
-  async dispatchServiceRequest({request}) {
+  dispatchServiceRequest({request}) {
     if (request?.kind) {
       const service = this.services?.[request?.kind];
       if (!service) {


### PR DESCRIPTION
The goal here is to allow `dispatchServiceRequest` to return null instead of a Promise-to-null so we can avoid the async delay. I definitely got it wrong a few times, please let me know if this makes sense.

The key was to avoid designating `dispatchServiceRequest` async.