### PR TITLE
Fix a bug where the hidden runner UI would cover/block other particles

### DIFF
--- a/pkg/Library/Dom/container-layout.js
+++ b/pkg/Library/Dom/container-layout.js
@@ -126,7 +126,11 @@ export class ContainerLayout extends DragDrop {
   updateOrders(target) {
     const particleDivs = this.querySelectorAll('[particle]');
     particleDivs.forEach(div => {
-      div.style.zIndex = (div === target ? 100 : 99);
+      if (!this.state.rects.find(rect => rect.id === div.id)) {
+        div.style.zIndex = 98;
+      } else {
+        div.style.zIndex = (div === target ? 100 : 99);
+      }
     });
   }
   // deselect when clicking empty backgroud


### PR DESCRIPTION
The fix is to set a lower z-index for particle divs that don't exist.