### PR TITLE
Clear canvas texture before updating

### DIFF
--- a/pkg/Library/Shader/ShaderService.js
+++ b/pkg/Library/Shader/ShaderService.js
@@ -146,7 +146,9 @@ const ShaderJunk = class {
   updateChannel(inChannel, inCanvas) {
     // inCanvas will be stretched to fix textureCanvas dimensions
     const {width, height} = inChannel.textureCanvas;
-    inChannel.textureCanvas.getContext('2d').drawImage(inCanvas, 0, 0, width, height);
+    const ctx = inChannel.textureCanvas.getContext('2d');
+    ctx.clearRect(0, 0, width, height);
+    ctx.drawImage(inCanvas, 0, 0, width, height);
     inChannel.texture.needsUpdate = true;
   }
   updateAudioChannel(inAudio) {


### PR DESCRIPTION
This is to fix situations where canvas source has transparent pixels, like the body segmentation result.

See:
https://screencast.googleplex.com/cast/NTU0MTUwNTI1NjEyODUxMnw2Y2E0NDA2OC04Yw