### PR TITLE
publish CSS variables for customizing NodeCatalog

### DIFF
--- a/pkg/Library/NodeCatalog/CategoryCatalog.js
+++ b/pkg/Library/NodeCatalog/CategoryCatalog.js
@@ -85,8 +85,8 @@ template: html`
   [category-container] {
     display: flex;
     flex-direction: column;
-    color: var(--theme-color-fg-0);
-    background-color: var(--theme-color-bg-0);
+    color: var(--category-catalog-fg-color, --theme-color-fg-0);
+    background-color: var(--category-catalog-bg-color, --theme-color-bg-0);
     height: 100%;
     flex-shrink: 0;
     overflow-y: auto;
@@ -105,7 +105,7 @@ template: html`
     background-color: var(--theme-color-bg-3);
   }
   [category][selected] {
-    background-color: var(--theme-color-bg-2);
+    background-color: var(--category-catalog-selected-color, --theme-color-bg-2);
   }
   [category-name] {
     font-size: 14px;

--- a/pkg/Library/NodeCatalog/NodeList.js
+++ b/pkg/Library/NodeCatalog/NodeList.js
@@ -69,8 +69,8 @@ formatNodeKey({name, index}) {
 onHoverNodeType({eventlet: {key, value}, selectedNodeTypes}, state) {
   const [category, name] = key.split(this.catalogDelimiter);
   state.showInfoPanel = true;
-  // 44 is the height of the toolbar.
-  state.infoPanelTop = value + 44;
+  // 34 is (approximately) the height of the toolbar
+  state.infoPanelTop = value + 34;
   const index = this.findNodeTypeIndex({name, category}, selectedNodeTypes.sort(this.sortNodeTypes));
   return {
     hoveredNodeType: selectedNodeTypes[index],
@@ -85,10 +85,13 @@ onMouseOutNodeType(inputs, state) {
 template: html`
 <style>
   :host {
+    /* theme variables */
     /* --nodelist-bg: #f8f9fa; */
-    --nodelist-bg: var(--theme-color-bg-2);
-    --nodelist-container-fg: var(--theme-color-fg-3);
-    --nodelist-container-hi: var(--theme-color-bg-3);
+    --nodelist-bg: var(--node-list-bg, --theme-color-bg-2);
+    --nodelist-container-fg: var(--nodelist-container-fg, --theme-color-fg-3);
+    --nodelist-container-hi: var(--nodelist-container-hi, --theme-color-bg-3);
+  }
+  :host {
     background-color: var(--nodelist-bg);
     height: 100%;
     overflow: hidden;


### PR DESCRIPTION
I'm proposing we solve #111 using CSS variables. 

This way the NodeGraph can be shared without battling over theme assignments.

I hadn't published the variables correctly, so it wasn't an option before! I'll post a matching Rapsai update.