### PR TITLE
Minor fix on node info panel's position on hover

### DIFF
--- a/pkg/Library/NodeCatalog/NodeList.js
+++ b/pkg/Library/NodeCatalog/NodeList.js
@@ -9,12 +9,15 @@ update({selectedNodeTypes}, state) {
   state.nodeTypeList = values(selectedNodeTypes).sort(this.sortNodeTypes);
 },
 
-render({}, {nodeTypeList, showInfoPanel, infoPanelTop}) {
+render({}, {nodeTypeList, showInfoPanel, infoPanelPos}) {
   return {
     nodeTypes: this.renderNodeTypes(nodeTypeList),
     hideNoMatchedNodesLabel: nodeTypeList.length !== 0,
     showInfoPanel: String(Boolean(showInfoPanel)),
-    infoPanelContainerStyle: {top: `${infoPanelTop}px`}
+    infoPanelContainerStyle: {
+      top: `${infoPanelPos?.top || 0}px`,
+      left: `${infoPanelPos?.left || 0}px`
+    }
   };
 },
 
@@ -70,7 +73,7 @@ formatNodeId(id, index) {
 onHoverNodeType({eventlet: {key, value}, selectedNodeTypes}, state) {
   assign(state, {
     showInfoPanel: true,
-    infoPanelTop: value
+    infoPanelPos: value
   });
   return {
     hoveredNodeType: selectedNodeTypes[key],
@@ -149,7 +152,6 @@ template: html`
     position: fixed;
     background: white;
     z-index: 1000;
-    left: 250px;
     padding: 12px;
     box-shadow: 0px 1px 2px rgba(60, 64, 67, 0.3), 0px 2px 6px 2px rgba(60, 64, 67, 0.15);
     border-radius: 8px;

--- a/pkg/Library/NodeCatalog/draggable-item.js
+++ b/pkg/Library/NodeCatalog/draggable-item.js
@@ -105,9 +105,8 @@ export class DraggableItem extends Xen.Async {
     // Get the distance between the item element and the top of the main
     // app container. This value will be used to position the popup panel that
     // shows the info the hovered item.
-    const offsetTop = this.host.host.offsetTop;
-    const scrollTop = this.host.host.parentElement.parentElement.scrollTop;
-    this.value = offsetTop - scrollTop;
+    const {top, left, width} = this.host.host.getBoundingClientRect();
+    this.value = {top, left: left + width};
     this.fire('enter');
   }
 


### PR DESCRIPTION
The `info-panel-container` has the [`fixed` position](https://github.com/project-oak/arcsjs-core/blob/main/pkg/Library/NodeCatalog/NodeList.js#L149), so using `getBoundingClientRect` on the `draggable-item` to get its position. 

This also makes the panel appear at the correct position in tests.

Before:
https://screenshot.googleplex.com/6bnnoVdCn6zWJ9T
https://screenshot.googleplex.com/3j5a5apXuSBZ7vw

After:
https://screenshot.googleplex.com/9qQDdDDev5WE8xt
https://screenshot.googleplex.com/4SCtFqL3j3tSTzj (with scrolled content)
https://screenshot.googleplex.com/syW2fg8576EgETT

Thanks!