### PR TITLE
Allow users to generate and copy "runner url" to clipboard

### DIFF
--- a/pkg/Library/App/HistoryService.js
+++ b/pkg/Library/App/HistoryService.js
@@ -10,12 +10,21 @@
 import {Params} from './Params.js';
 
 export const HistoryService = {
-  retrieveSelectedPipeline() {
+  retrieveSelectedPipeline({keepParam}) {
     const pipeline = Params.getParam('pipeline');
-    Params.replaceUrlParam('pipeline', null);
+    if (!keepParam) {
+      Params.replaceUrlParam('pipeline', null);
+    }
     return pipeline;
   },
   setSelectedPipeline({pipeline}) {
     Params.setUrlParam('pipeline', pipeline);
+  },
+  generateAndCopyRunnerUrlForPipeline({pipeline}) {
+    const url = new URL(document.URL);
+    const runnerUrl =
+        `${url.origin}${url.pathname.replace('studio', 'runner')}?pipeline=${
+            pipeline.$meta.id}`;
+    navigator.clipboard.writeText(runnerUrl);
   }
 };

--- a/pkg/Library/NodeGraph/PipelineToolbar.js
+++ b/pkg/Library/NodeGraph/PipelineToolbar.js
@@ -121,6 +121,7 @@
       showChooser: String(!renaming),
       showDeleteIcon: String(isOwned),
       showRefreshIcon,
+      showCopyPipelineUrlIcon: String(!isOwned),
       publishKeys,
       showPublish: String(isOwned && publishKeys.length > 0),
       showUnpublish: String(Boolean(pipeline?.$meta?.isPublished) && isOwned),
@@ -232,6 +233,13 @@
   findPipelineByName(name, pipelines) {
     return pipelines?.find(({$meta}) => $meta.name === name);
   },
+  async onCopyPipelineUrlClicked({pipeline}, state, {service}) {
+    await service({
+      kind: 'HistoryService',
+      msg: 'generateAndCopyRunnerUrlForPipeline',
+      data: {pipeline}
+    });
+  },
   onPublishPathChanged({eventlet: {value}}, state) {
     state.selectedPublishKey = value;
   },
@@ -273,6 +281,7 @@
   <mwc-icon-button title="Delete Pipeline" on-click="onDelete" icon="delete" display$="{{showDeleteIcon}}"></mwc-icon-button>
   <input rename type="text" value="{{name}}" display$="{{showRenameInput}}" autofocus on-change="onRename" on-blur="onRenameBlur">
   <mwc-icon-button title="Rename Pipeline" on-click="onRenameClicked" display$="{{showRenameIcon}}" icon="edit"></mwc-icon-button>
+  <mwc-icon-button title="Copy Pipeline Url" on-click="onCopyPipelineUrlClicked" display$="{{showCopyPipelineUrlIcon}}" icon="link"></mwc-icon-button>
   <div column separator></div>
   <select title="Publish Target" display$="{{showPublish}}" on-change="onPublishPathChanged" repeat="option_t">{{publishKeys}}</select>
   <mwc-icon-button title="Publish Pipeline" on-click="onShare" icon="public" display$="{{showPublish}}"></mwc-icon-button>


### PR DESCRIPTION
(This is part of this PR:
https://team-review.git.corp.google.com/c/rapsai-team/rapsai-core/+/1605638. See how it works here: https://screencast.googleplex.com/cast/NjcwNDMzNDUxNjUxODkxMnxhOTBkNDg4Zi0zNQ)

- Add a button to the pipeline toolbar to allow users to generate and copy the "runner url" to the clipboard.
- Update `HistoryService` to support this feature.