### PR TITLE
Use top/left instead of transform to position containers in container-layout

### DIFF
--- a/pkg/Library/Dom/container-layout.js
+++ b/pkg/Library/Dom/container-layout.js
@@ -126,10 +126,10 @@ export class ContainerLayout extends DragDrop {
   updateOrders(target) {
     const particleDivs = this.querySelectorAll('[particle]');
     particleDivs.forEach(div => {
-      if (!this.rects?.find(rect => rect.id === div.id)) {
+      if (!this.rects?.find(rect => rect.id === div.getAttribute('particle'))) {
         div.style.zIndex = 98;
       } else {
-        div.style.zIndex = (div === target ? 100 : 99);
+        div.style.zIndex = (div === target ? 101 : 100);
       }
     });
   }
@@ -231,7 +231,8 @@ export class ContainerLayout extends DragDrop {
   setBoxStyle(elt, {l, t, w, h}) {
     [l, t, w, h] = [l, t, w, h].map(Math.round);
     assign(elt.style, {
-      transform: `translate(${l}px, ${t}px)`,
+      left: `${l}px`,
+      top: `${t}px`,
       width: `${!(w>0) ? 0 : w}px`,
       height: `${!(h>0) ? 0 : h}px`
     });
@@ -271,7 +272,7 @@ export class ContainerLayout extends DragDrop {
     position: absolute;
     background-color: transparent;
     box-sizing: border-box;
-    transform: translate(-1000px, 0);
+    left: -1000px;
     z-index: 100;
   }
   [corner] {


### PR DESCRIPTION
I was trying to open a dialog from a particle panel in runner using `modal-view` (which has `position` set to `fixed`), but to my surprise, the `modal-view` is not covering the whole viewport of the page. Instead, it only covers the particle element. After some digging, I found that:

`For elements whose layout is governed by the CSS box model, any value other than none for the transform property also causes the element to establish a containing block for all descendants. Its padding box will be used to layout for all of its absolute-position descendants, fixed-position descendants, and descendant fixed background attachments.`
(from [here](https://www.w3.org/TR/css-transforms-1/))

I changed the transform to top/left which has the same final effects. Hope it is ok.

Also, some minor fixes to the z-index setting part. Now it can correctly match the target, and the updated z-index values will make things look right when opening a dialog (i.e. the dialog won't be covered by the boxer).

Thanks!