### PR TITLE
reset all media device state to `false` when switching to another graph

### DIFF
--- a/pkg/Library/NodeGraph/GraphToolbar.js
+++ b/pkg/Library/NodeGraph/GraphToolbar.js
@@ -8,7 +8,7 @@
  */
 ({
   async update(inputs, state, tools) {
-    const {graph, graphs} = inputs;
+    const {graph, graphs, mediaDeviceState} = inputs;
     const {service} = tools;
     const outputs = {};
     if (graph) {
@@ -16,6 +16,7 @@
         if (state.graph?.$meta?.id !== graph.$meta.id) {
           await this.updateSelectedGraphHistory(graph, service);
           outputs['selectedNodeId'] = keys(graph.nodes)?.[0];
+          outputs['mediaDeviceState'] = this.resetMediaDeviceState(mediaDeviceState);
         }
         state.graph = graph;
         assign(outputs, {
@@ -46,6 +47,10 @@
         graph: graph?.$meta?.id
       }
     });
+  },
+  resetMediaDeviceState(mediaDeviceState) {
+    keys(mediaDeviceState).forEach(key => mediaDeviceState[key] = false);
+    return mediaDeviceState;
   },
   updateItemInGraphs(graph, graphs) {
     const index = this.findGraphIndex(graph, graphs);

--- a/pkg/nodegraph/Library/NodegraphRecipe.js
+++ b/pkg/nodegraph/Library/NodegraphRecipe.js
@@ -33,7 +33,8 @@ const GraphToolbar = {
     $inputs: [
       {graph: 'selectedGraph'},
       'graphs',
-      {event: 'graphToolbarEvent'}
+      {event: 'graphToolbarEvent'},
+      'mediaDeviceState'
     ],
     $staticInputs: {
       publishPaths: {}
@@ -43,7 +44,8 @@ const GraphToolbar = {
       'selectedNodeId',
       'graphs',
       {icons: 'graphToolbarIcons'},
-      {event: 'graphToolbarEvent'}
+      {event: 'graphToolbarEvent'},
+      'mediaDeviceState'
     ],
     $slots: {
       buttons: {


### PR DESCRIPTION
this isn't quite the ideal place to do it, but it was the quickest way.